### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP (Model Context Protocol) server automatically generates complete Cypress Page Object classes **AND** comprehensive test suites for any web page.
 
+<a href="https://glama.ai/mcp/servers/@jprealini/cypress-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jprealini/cypress-mcp/badge" alt="Cypress Page Object & Test Generator MCP server" />
+</a>
+
 ## Features
 
 - **Web Scraping**: Uses Puppeteer to fetch and render web pages
@@ -218,4 +222,4 @@ The server uses Puppeteer with the following settings:
 
 ## Contributing
 
-To add support for new element types, interaction methods, or test patterns, modify the `generatePageObjectClass` and `generateCypressTests` functions in `main.ts`. 
+To add support for new element types, interaction methods, or test patterns, modify the `generatePageObjectClass` and `generateCypressTests` functions in `main.ts`.


### PR DESCRIPTION
This PR adds a badge for the [MCP Cypress Page Object & Test Generator](https://glama.ai/mcp/servers/@jprealini/cypress-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jprealini/cypress-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jprealini/cypress-mcp/badge" alt="Cypress Page Object & Test Generator MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.